### PR TITLE
fix: set @else itself as a directive

### DIFF
--- a/corpus/if-statements.txt
+++ b/corpus/if-statements.txt
@@ -61,7 +61,8 @@ conditional keywords
       (directive)
       (parameter))
     (html)
-    (conditional_keyword)
+    (conditional_keyword
+      (directive))
     (html)
     (directive_end)))
 
@@ -292,7 +293,8 @@ custom directive
       (directive)
       (parameter))
     (html)
-    (conditional_keyword)
+    (conditional_keyword
+      (directive))
     (html)
     (directive_end))
   (conditional

--- a/grammar.js
+++ b/grammar.js
@@ -188,7 +188,7 @@ module.exports = grammar({
         // used in the conditional body rules
         conditional_keyword: ($) =>
             choice(
-                '@else',
+                alias('@else', $.directive),
                 seq(
                     alias(/@(elseif|else[a-zA-Z]+)/, $.directive),
                     optional($._directive_parameter)


### PR DESCRIPTION
Hi, I adjusted the `@else` itself as it is not recognized as a `directive`.

As a side note, I didn't include files under `src/*` in the pull request, so please generate and try it on your own.

---

**Before**:

<img width="535" alt="1_tree-sitter-blade-before" src="https://github.com/EmranMR/tree-sitter-blade/assets/188642/7a1fed86-0cee-46ba-b459-41d0690c7102">

**After**:

<img width="517" alt="2_tree-sitter-blade-after" src="https://github.com/EmranMR/tree-sitter-blade/assets/188642/cfc24b2f-9ed9-4439-8551-c1c46a64a995">
