### PR TITLE
chore: bump version to 0.9.7 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tree-sitter-blade",
-    "version": "0.9.0",
+    "version": "0.9.7",
     "description": "",
     "main": "bindings/node",
     "scripts": {


### PR DESCRIPTION
The version of package.json was not updated, so I adjusted it.