### PR TITLE
POC #28, #34, #33

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -13,11 +13,13 @@ module.exports = grammar({
                 $._nested_directive,
                 $.loop_operator,
                 $.comment,
-                $.text
+                $.text,
+                $.alpine_js
             ),
 
         // https://stackoverflow.com/questions/13014947/regex-to-match-a-c-style-multiline-comment/36328890#36328890
-        comment: $ => token(seq('{{--', /[^-]*-+([^}-][^-]*-+)*/, '}}')),
+        comment: ($) =>
+            token(seq('{{--', /[^-]*-+([^}-][^-]*-+)*/, '}}')),
 
         // !keywords
         keyword: ($) =>
@@ -488,6 +490,14 @@ module.exports = grammar({
                 alias('@endvolt', $.directive_end)
             ),
 
+        alpine_js: ($) =>
+            seq(
+                token(prec(1, /x-[a-zA-Z1-9]+=/)),
+                token(prec(1, /[\"\']/)),
+                $.text,
+                token(prec(1, /[\"\']/))
+            ),
+
         /*------------------------------------
         /  Do NOT change below this line   /
         /  without running tests           /
@@ -544,11 +554,11 @@ module.exports = grammar({
         _text: ($) =>
             choice(
                 token(prec(-1, /@[a-zA-Z\d]*[^\(-]/)), // custom directive conflict resolution
-                token(prec(-2, /[{}!@()?,-]/)), // orphan tags
+                token(prec(-2, /[\"\'x{}!@()?,-]/)), // orphan tags
                 token(
                     prec(
                         -1,
-                        /[^\s(){!}@-]([^(){!}@,?]*[^{!}()@?,-])?/ //general text
+                        /[^\"\'\sx(){!}@-]([^\"\'x(){!}@,?]*[^\"\'x{!}()@?,-])?/ //general text
                     )
                 )
             ),

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,15 +1,17 @@
 ((text) @injection.content
-    (#not-has-ancestor? @injection.content "envoy")
+    (#not-has-ancestor? @injection.content "envoy" "alpine_js")
     (#set! injection.combined)
     (#set! injection.language php))
 
-; could be bash or zsh
-; or whatever tree-sitter grammar you have.
 ((text) @injection.content
     (#has-ancestor? @injection.content "envoy")
     (#set! injection.combined)
-    (#set! injection.language bash))
+    (#set! injection.language shell))
 
+((text) @injection.content
+    (#has-ancestor? @injection.content "alpine_js")
+    (#set! injection.combined)
+    (#set! injection.language js))
 
 ((php_only) @injection.content
     (#set! injection.language php_only))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -42,6 +42,10 @@
         {
           "type": "SYMBOL",
           "name": "text"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alpine_js"
         }
       ]
     },
@@ -2047,6 +2051,48 @@
         }
       ]
     },
+    "alpine_js": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "PATTERN",
+              "value": "x-[a-zA-Z1-9]+="
+            }
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "PATTERN",
+              "value": "[\\\"\\']"
+            }
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "text"
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "PATTERN",
+              "value": "[\\\"\\']"
+            }
+          }
+        }
+      ]
+    },
     "_directive_body": {
       "type": "REPEAT1",
       "content": {
@@ -2351,7 +2397,7 @@
             "value": -2,
             "content": {
               "type": "PATTERN",
-              "value": "[{}!@()?,-]"
+              "value": "[\\\"\\'x{}!@()?,-]"
             }
           }
         },
@@ -2362,7 +2408,7 @@
             "value": -1,
             "content": {
               "type": "PATTERN",
-              "value": "[^\\s(){!}@-]([^(){!}@,?]*[^{!}()@?,-])?"
+              "value": "[^\\\"\\'\\sx(){!}@-]([^\\\"\\'x(){!}@,?]*[^\\\"\\'x{!}()@?,-])?"
             }
           }
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1,5 +1,20 @@
 [
   {
+    "type": "alpine_js",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "attribute",
     "named": true,
     "fields": {},
@@ -34,6 +49,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "alpine_js",
+          "named": true
+        },
         {
           "type": "attribute",
           "named": true
@@ -142,6 +161,10 @@
       "required": false,
       "types": [
         {
+          "type": "alpine_js",
+          "named": true
+        },
+        {
           "type": "attribute",
           "named": true
         },
@@ -236,6 +259,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "alpine_js",
+          "named": true
+        },
         {
           "type": "attribute",
           "named": true
@@ -379,6 +406,10 @@
       "required": true,
       "types": [
         {
+          "type": "alpine_js",
+          "named": true
+        },
+        {
           "type": "attribute",
           "named": true
         },
@@ -481,6 +512,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "alpine_js",
+          "named": true
+        },
         {
           "type": "attribute",
           "named": true
@@ -627,6 +662,10 @@
       "required": true,
       "types": [
         {
+          "type": "alpine_js",
+          "named": true
+        },
+        {
           "type": "attribute",
           "named": true
         },
@@ -729,6 +768,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "alpine_js",
+          "named": true
+        },
         {
           "type": "attribute",
           "named": true
@@ -860,6 +903,10 @@
       "required": true,
       "types": [
         {
+          "type": "alpine_js",
+          "named": true
+        },
+        {
           "type": "attribute",
           "named": true
         },
@@ -981,6 +1028,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "alpine_js",
+          "named": true
+        },
         {
           "type": "attribute",
           "named": true
@@ -1133,6 +1184,10 @@
       "required": true,
       "types": [
         {
+          "type": "alpine_js",
+          "named": true
+        },
+        {
           "type": "attribute",
           "named": true
         },
@@ -1236,6 +1291,10 @@
       "required": true,
       "types": [
         {
+          "type": "alpine_js",
+          "named": true
+        },
+        {
           "type": "attribute",
           "named": true
         },
@@ -1338,6 +1397,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "alpine_js",
+          "named": true
+        },
         {
           "type": "attribute",
           "named": true
@@ -1446,6 +1509,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "alpine_js",
+          "named": true
+        },
         {
           "type": "attribute",
           "named": true


### PR DESCRIPTION
Hi @calebdw following on from our discussion on #33.

As much as I love your solution, which is a common sense and more semantic, things are a bit more convoluted for Nova (maybe zed as well?). 

For those editors at the moment, it is **not** possible, for extensions or users to access the built-in parsers `html/query/injections.scm` , [in fact I requested this from Panic on the forum back in August](https://devforum.nova.app/t/extending-injections-for-first-and-third-party-syntax-extensions/2327) when you posted your alpineJS snippet on the "Discussions", which I found pretty cool for NeoVim.

> no way of knowing without copying a lot of the html parser 

However this POC shows how these can be implemented as first party as a work around, without actually using any duplication from `tree-sitter-html`:

#### The following is what is implemented in the POC:
1. parser picks up alpine attributes
2. `injections.scm` is adjusted to inject `JS` inside the quotes

At the moment, the only problem, with this POC is the painting, which is easily fixed.
#### Highlighting fix using `highlights.scm` & few touch ups for the `grammar.js`:
1. create a nodes to capture for the `alpine attribute` & `"` 
2. Painting quotes as "attribute quotes"
3. Painting alpine attributes as "attributes"

Both of  which can be fixed in two lines in `highlights.scm`, here is a hypothetical example for Nova.
```scm
(attribute_name) @attribute
(quotes) @tag.attribute.value.delimiter ;not sure what this is for neovim
```

Can I please have your opinion on this, as you are quite experienced with `tree-sitter` and of course as a NeoVim user.

1. I could just define the grammars, and commit to main, then NVim users just copy and paste stubs to `highlights.scm` and `injections.scm` inside their `tree-sitter-blade` copy
2. Branching out from `main` for Nova, and maintain two parallel branches, merging the future features as added to the Nova branch (absolutely not my favourite because of the development overhead)!

I personally like option 1, because it makes my life easy. I will try to bundle all those issues into one release, with users of the parser having to just copy and paste the stubs provided into two files once and for all. It is sort of future proof as well, everything encapsulated and maintained inside `tree-sitter-blade`. 
