### PR TITLE
chore: add example parsing script

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/package.json
+++ b/package.json
@@ -6,37 +6,12 @@
     "keywords": [
         "tree-sitter-blade",
         "blade",
-        "tree-sitter",
-        "laravel"
-    ],
-    "homepage": "https://github.com/EmranMR/tree-sitter-blade",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/EmranMR/tree-sitter-blade"
-    },
-    "bugs": "https://github.com/EmranMR/tree-sitter-blade/issues",
-    "funding": "https://github.com/sponsors/EmranMR",
-    "scripts": {
-        "test": "tree-sitter generate && tree-sitter test",
-        "parse": "tree-sitter generate && tree-sitter parse example-file.blade",
-        "generate": "tree-sitter generate"
-    },
-    "author": "Emran Mashhadi Ramezan",
-    "license": "MIT",
-    "dependencies": {
-        "nan": "^2.17.0"
-    },
-    "devDependencies": {
-        "tree-sitter-cli": "^0.20.8"
-    },
-    "tree-sitter": [
-        {
-            "scope": "source.blade.php",
-            "file-types": [
-                "blade",
-                "php"
-            ],
-            "injection-regex": "blade"
-        }
-    ]
+        "php"
+      ],
+      "injection-regex": "blade",
+      "highlights": "queries/highlights.scm",
+      "injections": "queries/injections-text.scm",
+      "folds": "queries/folds.scm"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,38 @@
 {
-    "name": "tree-sitter-blade",
-    "version": "0.9.2",
-    "description": "tree-sitter-blade grammar for Laravel Blade files",
-    "main": "bindings/node",
-    "keywords": [
-        "tree-sitter-blade",
+  "name": "tree-sitter-blade",
+  "version": "0.9.2",
+  "description": "tree-sitter-blade grammar for Laravel Blade files",
+  "main": "bindings/node",
+  "keywords": [
+    "tree-sitter-blade",
+    "blade",
+    "tree-sitter",
+    "laravel"
+  ],
+  "homepage": "https://github.com/EmranMR/tree-sitter-blade",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/EmranMR/tree-sitter-blade"
+  },
+  "bugs": "https://github.com/EmranMR/tree-sitter-blade/issues",
+  "funding": "https://github.com/sponsors/EmranMR",
+  "scripts": {
+    "build": "tree-sitter generate",
+    "test": "tree-sitter test",
+    "test-examples": "script/parse-examples"
+  },
+  "author": "Emran Mashhadi Ramezan",
+  "license": "MIT",
+  "dependencies": {
+    "nan": "^2.17.0"
+  },
+  "devDependencies": {
+    "tree-sitter-cli": "^0.20.8"
+  },
+  "tree-sitter": [
+    {
+      "scope": "source.blade.php",
+      "file-types": [
         "blade",
         "php"
       ],

--- a/script/known-failures.txt
+++ b/script/known-failures.txt
@@ -1,0 +1,2 @@
+examples/breeze/stubs/default/resources/views/components/input-error.blade.php
+examples/breeze/stubs/default/resources/views/components/modal.blade.php

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -eu
+
+cd "$(dirname "$0")/.."
+
+function clone_repo {
+  owner=$1
+  name=$2
+  sha=$3
+
+  path=examples/$name
+  if [ ! -d "$path" ]; then
+    echo "Cloning $owner/$name"
+    git clone "https://github.com/$owner/$name" "$path"
+  fi
+
+  pushd "$path" >/dev/null
+  actual_sha=$(git rev-parse HEAD)
+  if [ "$actual_sha" != "$sha" ]; then
+    echo "Updating $owner/$name to $sha"
+    git fetch
+    git reset --hard "$sha"
+  fi
+  popd >/dev/null
+}
+
+clone_repo laravel breeze 4dce985b91081bd0bfd31c612bdbb0fd2187a89b
+
+known_failures=$(cat script/known-failures.txt)
+
+# shellcheck disable=2046
+tree-sitter parse -q \
+  examples/**/*.blade.php \
+  $(for file in $known_failures; do echo "!${file}"; done)
+
+example_count=$(find examples -name '*.blade.php' | wc -l)
+failure_count=$(wc -w <<<"$known_failures")
+success_count=$((example_count - failure_count))
+success_percent=$(bc -l <<<"100*${success_count}/${example_count}")
+
+printf \
+  "Successfully parsed %d of %d example files (%.1f%%)\n" \
+  $success_count $example_count $success_percent

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -30,7 +30,7 @@ clone_repo laravel breeze 4dce985b91081bd0bfd31c612bdbb0fd2187a89b
 known_failures=$(cat script/known-failures.txt)
 
 # shellcheck disable=2046
-tree-sitter parse -q \
+tree-sitter parse -q --scope source.blade.php \
   examples/**/*.blade.php \
   $(for file in $known_failures; do echo "!${file}"; done)
 


### PR DESCRIPTION
Hello!

This adds an example parsing script similar to other tree-sitter repos. The script is used to checkout repos and execute the grammar on the files to ensure there's no issues parsing files in the community. Currently this is just parsing Breeze, but we can add other popular repos as needed/desired.


This actually revealed two bugs (I'll open an issue):
1. `@js` is parsed as a conditional
2. No support for casting `@foreach((array) $messages as $message)`

Thanks!