### PR TITLE
feature: support scoped slots

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -6,16 +6,18 @@
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@std/assert@*": "0.223.0",
     "jsr:@std/assert@0.223": "0.223.0",
+    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/bytes@0.223": "0.223.0",
     "jsr:@std/bytes@^1.0.2": "1.0.5",
     "jsr:@std/encoding@^1.0.5": "1.0.7",
     "jsr:@std/fmt@0.223": "0.223.0",
     "jsr:@std/fs@0.223": "0.223.0",
+    "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/io@0.223": "0.223.0",
     "jsr:@std/path@0.223": "0.223.0",
     "jsr:@std/path@^1.0.6": "1.0.8",
     "jsr:@trx/deno-bundle@*": "0.1.0",
-    "npm:@types/node@*": "22.5.4",
+    "npm:@types/node@*": "22.15.32",
     "npm:@types/node@^22.15.32": "22.15.32",
     "npm:esbuild@0.20.2": "0.20.2",
     "npm:node-addon-api@^8.4.0": "8.4.0",
@@ -55,6 +57,12 @@
         "jsr:@std/fmt"
       ]
     },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
     "@std/bytes@0.223.0": {
       "integrity": "84b75052cd8680942c397c2631318772b295019098f40aac5c36cead4cba51a8"
     },
@@ -69,6 +77,9 @@
     },
     "@std/fs@0.223.0": {
       "integrity": "3b4b0550b2c524cbaaa5a9170c90e96cbb7354e837ad1bdaf15fc9df1ae9c31c"
+    },
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
     "@std/io@0.223.0": {
       "integrity": "2d8c3c2ab3a515619b90da2c6ff5ea7b75a94383259ef4d02116b228393f84f1",
@@ -212,13 +223,7 @@
     "@types/node@22.15.32": {
       "integrity": "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==",
       "dependencies": [
-        "undici-types@6.21.0"
-      ]
-    },
-    "@types/node@22.5.4": {
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
-      "dependencies": [
-        "undici-types@6.19.8"
+        "undici-types"
       ]
     },
     "base64-js@1.5.1": {
@@ -385,9 +390,6 @@
       "scripts": true,
       "bin": true
     },
-    "undici-types@6.19.8": {
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
-    },
     "undici-types@6.21.0": {
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
@@ -399,6 +401,11 @@
     }
   },
   "workspace": {
+    "dependencies": [
+      "jsr:@luca/esbuild-deno-loader@~0.11.1",
+      "jsr:@std/assert@1",
+      "npm:esbuild@0.20.2"
+    ],
     "packageJson": {
       "dependencies": [
         "npm:@types/node@^22.15.32",

--- a/grammar.js
+++ b/grammar.js
@@ -986,12 +986,13 @@ var grammar_default = grammar(import_grammar.default, {
     text: ($) => prec.right(repeat1($._text)),
     // hidden to reduce AST noise in php_only #39
     // It is selectively unhidden for other areas
+    // escaped blade directives e.g. @@if, @@csrf
+    _escaped_directive: (_) => token(prec(1, /@@[a-zA-Z\d]*/)),
     // Create alternative text rep for php_only
-    _text: (_) => (
+    _text: ($) => (
       // custom directive conflict resolution
       choice(
-        // escaped blade directives e.g. @@if, @@csrf
-        token(prec(1, /@@[a-zA-Z\d]*/)),
+        $._escaped_directive,
         token(prec(-1, /@[a-zA-Z\d]*[^\(-]/)),
         // orphan tags
         token(prec(-2, /[{}!@()?,-]/)),
@@ -1004,21 +1005,19 @@ var grammar_default = grammar(import_grammar.default, {
         )
       )
     ),
-    _singly_quoted_attribute_text: (_) => prec.right(
+    _singly_quoted_attribute_text: ($) => prec.right(
       repeat1(
         choice(
-          // escaped blade directives e.g. @@if, @@csrf
-          token(prec(1, /@@[a-zA-Z\d]*/)),
+          $._escaped_directive,
           token(prec(-2, /[{}]/)),
           token(prec(-1, /[^'{}]/))
         )
       )
     ),
-    _doubly_quoted_attribute_text: (_) => prec.right(
+    _doubly_quoted_attribute_text: ($) => prec.right(
       repeat1(
         choice(
-          // escaped blade directives e.g. @@if, @@csrf
-          token(prec(1, /@@[a-zA-Z\d]*/)),
+          $._escaped_directive,
           token(prec(-2, /[{}]/)),
           token(prec(-1, /[^"{}]/))
         )

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4127,19 +4127,23 @@
         }
       ]
     },
+    "_escaped_directive": {
+      "type": "TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": 1,
+        "content": {
+          "type": "PATTERN",
+          "value": "@@[a-zA-Z\\d]*"
+        }
+      }
+    },
     "_text": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "TOKEN",
-          "content": {
-            "type": "PREC",
-            "value": 1,
-            "content": {
-              "type": "PATTERN",
-              "value": "@@[a-zA-Z\\d]*"
-            }
-          }
+          "type": "SYMBOL",
+          "name": "_escaped_directive"
         },
         {
           "type": "TOKEN",
@@ -4185,15 +4189,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "TOKEN",
-              "content": {
-                "type": "PREC",
-                "value": 1,
-                "content": {
-                  "type": "PATTERN",
-                  "value": "@@[a-zA-Z\\d]*"
-                }
-              }
+              "type": "SYMBOL",
+              "name": "_escaped_directive"
             },
             {
               "type": "TOKEN",
@@ -4230,15 +4227,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "TOKEN",
-              "content": {
-                "type": "PREC",
-                "value": 1,
-                "content": {
-                  "type": "PATTERN",
-                  "value": "@@[a-zA-Z\\d]*"
-                }
-              }
+              "type": "SYMBOL",
+              "name": "_escaped_directive"
             },
             {
               "type": "TOKEN",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -40,7 +40,7 @@ static unsigned serialize(Scanner *scanner, char *buffer) {
 
     for (; serialized_tag_count < tag_count; serialized_tag_count++) {
         Tag tag = scanner->tags.contents[serialized_tag_count];
-        if (tag.type == CUSTOM) {
+        if (tag.type == CUSTOM || tag.type == X_SLOT) {
             unsigned name_length = tag.custom_tag_name.size;
             if (name_length > UINT8_MAX) {
                 name_length = UINT8_MAX;
@@ -87,7 +87,7 @@ static void deserialize(Scanner *scanner, const char *buffer, unsigned length) {
             for (iter = 0; iter < serialized_tag_count; iter++) {
                 Tag tag = tag_new();
                 tag.type = (TagType)buffer[size++];
-                if (tag.type == CUSTOM) {
+                if (tag.type == CUSTOM || tag.type == X_SLOT) {
                     uint16_t name_length = (uint8_t)buffer[size++];
                     array_reserve(&tag.custom_tag_name, name_length);
                     tag.custom_tag_name.size = name_length;

--- a/src/tag.h
+++ b/src/tag.h
@@ -7,6 +7,9 @@
 
 #include <string.h>
 
+#define X_SLOT_TAG "X-SLOT"
+#define X_SLOT_TAG_LEN (sizeof(X_SLOT_TAG) - 1)
+
 typedef enum {
     AREA,
     BASE,
@@ -137,6 +140,7 @@ typedef enum {
     VIDEO,
 
     CUSTOM,
+    X_SLOT,
 
     END_,
 } TagType;
@@ -153,7 +157,7 @@ typedef struct {
     String custom_tag_name;
 } Tag;
 
-static const TagMapEntry TAG_TYPES_BY_TAG_NAME[126] = {
+static const TagMapEntry TAG_TYPES_BY_TAG_NAME[127] = {
     {"AREA",       AREA      },
     {"BASE",       BASE      },
     {"BASEFONT",   BASEFONT  },
@@ -280,6 +284,7 @@ static const TagMapEntry TAG_TYPES_BY_TAG_NAME[126] = {
     {"VAR",        VAR       },
     {"VIDEO",      VIDEO     },
     {"CUSTOM",     CUSTOM    },
+    {X_SLOT_TAG,   X_SLOT    },
 };
 
 static const TagType TAG_TYPES_NOT_ALLOWED_IN_PARAGRAPHS[] = {
@@ -290,7 +295,7 @@ static const TagType TAG_TYPES_NOT_ALLOWED_IN_PARAGRAPHS[] = {
 };
 
 static TagType tag_type_for_name(const String *tag_name) {
-    for (int i = 0; i < 126; i++) {
+    for (int i = 0; i < 127; i++) {
         const TagMapEntry *entry = &TAG_TYPES_BY_TAG_NAME[i];
         if (
             strlen(entry->tag_name) == tag_name->size &&
@@ -298,6 +303,12 @@ static TagType tag_type_for_name(const String *tag_name) {
         ) {
             return entry->tag_type;
         }
+    }
+    if (
+        tag_name->size > X_SLOT_TAG_LEN + 1 &&
+        memcmp(tag_name->contents, X_SLOT_TAG ":", X_SLOT_TAG_LEN + 1) == 0
+    ) {
+        return X_SLOT;
     }
     return CUSTOM;
 }
@@ -312,7 +323,7 @@ static inline Tag tag_new() {
 static inline Tag tag_for_name(String name) {
     Tag tag = tag_new();
     tag.type = tag_type_for_name(&name);
-    if (tag.type == CUSTOM) {
+    if (tag.type == CUSTOM || tag.type == X_SLOT) {
         tag.custom_tag_name = name;
     } else {
         array_delete(&name);
@@ -321,7 +332,7 @@ static inline Tag tag_for_name(String name) {
 }
 
 static inline void tag_free(Tag *tag) {
-    if (tag->type == CUSTOM) {
+    if (tag->type == CUSTOM || tag->type == X_SLOT) {
         array_delete(&tag->custom_tag_name);
     }
 }
@@ -332,7 +343,10 @@ static inline bool tag_is_void(const Tag *self) {
 
 static inline bool tag_eq(const Tag *self, const Tag *other) {
     if (self->type != other->type) return false;
-    if (self->type == CUSTOM) {
+    if (self->type == X_SLOT && other->custom_tag_name.size == X_SLOT_TAG_LEN) {
+        return true;
+    }
+    if (self->type == CUSTOM || self->type == X_SLOT) {
         if (self->custom_tag_name.size != other->custom_tag_name.size) {
             return false;
         }

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -52,96 +52,67 @@ extern "C" {
 
 /// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
 /// less than the array's current capacity, this function has no effect.
-#define array_reserve(self, new_capacity)        \
-  ((self)->contents = _array__reserve(           \
-    (void *)(self)->contents, &(self)->capacity, \
-    array_elem_size(self), new_capacity)         \
-  )
+#define array_reserve(self, new_capacity) \
+  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
 
 /// Free any memory allocated for this array. Note that this does not free any
 /// memory allocated for the array's contents.
-#define array_delete(self)                           \
-  do {                                               \
-    if ((self)->contents) ts_free((self)->contents); \
-    (self)->contents = NULL;                         \
-    (self)->size = 0;                                \
-    (self)->capacity = 0;                            \
-  } while (0)
+#define array_delete(self) _array__delete((Array *)(self))
 
 /// Push a new `element` onto the end of the array.
-#define array_push(self, element)                                 \
-  do {                                                            \
-    (self)->contents = _array__grow(                              \
-      (void *)(self)->contents, (self)->size, &(self)->capacity,  \
-      1, array_elem_size(self)                                    \
-    );                                                            \
-   (self)->contents[(self)->size++] = (element);                  \
-  } while(0)
+#define array_push(self, element)                            \
+  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
+   (self)->contents[(self)->size++] = (element))
 
 /// Increase the array's size by `count` elements.
 /// New elements are zero-initialized.
-#define array_grow_by(self, count)                                               \
-  do {                                                                           \
-    if ((count) == 0) break;                                                     \
-    (self)->contents = _array__grow(                                             \
-      (self)->contents, (self)->size, &(self)->capacity,                         \
-      count, array_elem_size(self)                                               \
-    );                                                                           \
+#define array_grow_by(self, count) \
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
     memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
-    (self)->size += (count);                                                     \
+    (self)->size += (count); \
   } while (0)
 
 /// Append all elements from one array to the end of another.
-#define array_push_all(self, other) \
+#define array_push_all(self, other)                                       \
   array_extend((self), (other)->size, (other)->contents)
 
 /// Append `count` elements to the end of the array, reading their values from the
 /// `contents` pointer.
-#define array_extend(self, count, other_contents)                 \
-  (self)->contents = _array__splice(                              \
-    (void*)(self)->contents, &(self)->size, &(self)->capacity,    \
-    array_elem_size(self), (self)->size, 0, count, other_contents \
+#define array_extend(self, count, contents)                    \
+  _array__splice(                                               \
+    (Array *)(self), array_elem_size(self), (self)->size, \
+    0, count,  contents                                        \
   )
 
 /// Remove `old_count` elements from the array starting at the given `index`. At
 /// the same index, insert `new_count` new elements, reading their values from the
 /// `new_contents` pointer.
-#define array_splice(self, _index, old_count, new_count, new_contents) \
-  (self)->contents = _array__splice(                                   \
-    (void *)(self)->contents, &(self)->size, &(self)->capacity,        \
-    array_elem_size(self), _index, old_count, new_count, new_contents  \
+#define array_splice(self, _index, old_count, new_count, new_contents)  \
+  _array__splice(                                                       \
+    (Array *)(self), array_elem_size(self), _index,                \
+    old_count, new_count, new_contents                                 \
   )
 
 /// Insert one `element` into the array at the given `index`.
-#define array_insert(self, _index, element)                     \
-  (self)->contents = _array__splice(                            \
-    (void *)(self)->contents, &(self)->size, &(self)->capacity, \
-    array_elem_size(self), _index, 0, 1, &(element)             \
-  )
+#define array_insert(self, _index, element) \
+  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
 
 /// Remove one element from the array at the given `index`.
 #define array_erase(self, _index) \
-  _array__erase((void *)(self)->contents, &(self)->size, array_elem_size(self), _index)
+  _array__erase((Array *)(self), array_elem_size(self), _index)
 
 /// Pop the last element off the array, returning the element by value.
 #define array_pop(self) ((self)->contents[--(self)->size])
 
 /// Assign the contents of one array to another, reallocating if necessary.
-#define array_assign(self, other)                                   \
-  (self)->contents = _array__assign(                                \
-    (void *)(self)->contents, &(self)->size, &(self)->capacity,     \
-    (const void *)(other)->contents, (other)->size, array_elem_size(self) \
-  )
+#define array_assign(self, other) \
+  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
 
 /// Swap one array with another
-#define array_swap(self, other)                                     \
-  do {                                                              \
-    void *_array_swap_tmp = (void *)(self)->contents;               \
-    (self)->contents = (other)->contents;                           \
-    (other)->contents = _array_swap_tmp;                            \
-    _array__swap(&(self)->size, &(self)->capacity,                  \
-                 &(other)->size, &(other)->capacity);               \
-  } while (0)
+#define array_swap(self, other) \
+  _array__swap((Array *)(self), (Array *)(other))
 
 /// Get the size of the array contents
 #define array_elem_size(self) (sizeof *(self)->contents)
@@ -186,90 +157,82 @@ extern "C" {
 
 // Private
 
-// Pointers to individual `Array` fields (rather than the entire `Array` itself)
-// are passed to the various `_array__*` functions below to address strict aliasing
-// violations that arises when the _entire_ `Array` struct is passed as `Array(void)*`.
-//
-// The `Array` type itself was not altered as a solution in order to avoid breakage
-// with existing consumers (in particular, parsers with external scanners).
+typedef Array(void) Array;
+
+/// This is not what you're looking for, see `array_delete`.
+static inline void _array__delete(Array *self) {
+  if (self->contents) {
+    ts_free(self->contents);
+    self->contents = NULL;
+    self->size = 0;
+    self->capacity = 0;
+  }
+}
 
 /// This is not what you're looking for, see `array_erase`.
-static inline void _array__erase(void* self_contents, uint32_t *size,
-                                size_t element_size, uint32_t index) {
-  assert(index < *size);
-  char *contents = (char *)self_contents;
+static inline void _array__erase(Array *self, size_t element_size,
+                                uint32_t index) {
+  assert(index < self->size);
+  char *contents = (char *)self->contents;
   memmove(contents + index * element_size, contents + (index + 1) * element_size,
-          (*size - index - 1) * element_size);
-  (*size)--;
+          (self->size - index - 1) * element_size);
+  self->size--;
 }
 
 /// This is not what you're looking for, see `array_reserve`.
-static inline void *_array__reserve(void *contents, uint32_t *capacity,
-                                  size_t element_size, uint32_t new_capacity) {
-  void *new_contents = contents;
-  if (new_capacity > *capacity) {
-    if (contents) {
-      new_contents = ts_realloc(contents, new_capacity * element_size);
+static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
+  if (new_capacity > self->capacity) {
+    if (self->contents) {
+      self->contents = ts_realloc(self->contents, new_capacity * element_size);
     } else {
-      new_contents = ts_malloc(new_capacity * element_size);
+      self->contents = ts_malloc(new_capacity * element_size);
     }
-    *capacity = new_capacity;
+    self->capacity = new_capacity;
   }
-  return new_contents;
 }
 
 /// This is not what you're looking for, see `array_assign`.
-static inline void *_array__assign(void* self_contents, uint32_t *self_size, uint32_t *self_capacity,
-                                 const void *other_contents, uint32_t other_size, size_t element_size) {
-  void *new_contents = _array__reserve(self_contents, self_capacity, element_size, other_size);
-  *self_size = other_size;
-  memcpy(new_contents, other_contents, *self_size * element_size);
-  return new_contents;
+static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
+  _array__reserve(self, element_size, other->size);
+  self->size = other->size;
+  memcpy(self->contents, other->contents, self->size * element_size);
 }
 
 /// This is not what you're looking for, see `array_swap`.
-static inline void _array__swap(uint32_t *self_size, uint32_t *self_capacity,
-                               uint32_t *other_size, uint32_t *other_capacity) {
-  uint32_t tmp_size = *self_size;
-  uint32_t tmp_capacity = *self_capacity;
-  *self_size = *other_size;
-  *self_capacity = *other_capacity;
-  *other_size = tmp_size;
-  *other_capacity = tmp_capacity;
+static inline void _array__swap(Array *self, Array *other) {
+  Array swap = *other;
+  *other = *self;
+  *self = swap;
 }
 
 /// This is not what you're looking for, see `array_push` or `array_grow_by`.
-static inline void *_array__grow(void *contents, uint32_t size, uint32_t *capacity,
-                               uint32_t count, size_t element_size) {
-  void *new_contents = contents;
-  uint32_t new_size = size + count;
-  if (new_size > *capacity) {
-    uint32_t new_capacity = *capacity * 2;
+static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
+  uint32_t new_size = self->size + count;
+  if (new_size > self->capacity) {
+    uint32_t new_capacity = self->capacity * 2;
     if (new_capacity < 8) new_capacity = 8;
     if (new_capacity < new_size) new_capacity = new_size;
-    new_contents = _array__reserve(contents, capacity, element_size, new_capacity);
+    _array__reserve(self, element_size, new_capacity);
   }
-  return new_contents;
 }
 
 /// This is not what you're looking for, see `array_splice`.
-static inline void *_array__splice(void *self_contents, uint32_t *size, uint32_t *capacity,
-                                 size_t element_size,
+static inline void _array__splice(Array *self, size_t element_size,
                                  uint32_t index, uint32_t old_count,
                                  uint32_t new_count, const void *elements) {
-  uint32_t new_size = *size + new_count - old_count;
+  uint32_t new_size = self->size + new_count - old_count;
   uint32_t old_end = index + old_count;
   uint32_t new_end = index + new_count;
-  assert(old_end <= *size);
+  assert(old_end <= self->size);
 
-  void *new_contents = _array__reserve(self_contents, capacity, element_size, new_size);
+  _array__reserve(self, element_size, new_size);
 
-  char *contents = (char *)new_contents;
-  if (*size > old_end) {
+  char *contents = (char *)self->contents;
+  if (self->size > old_end) {
     memmove(
       contents + new_end * element_size,
       contents + old_end * element_size,
-      (*size - old_end) * element_size
+      (self->size - old_end) * element_size
     );
   }
   if (new_count > 0) {
@@ -287,9 +250,7 @@ static inline void *_array__splice(void *self_contents, uint32_t *size, uint32_t
       );
     }
   }
-  *size += new_count - old_count;
-
-  return new_contents;
+  self->size += new_count - old_count;
 }
 
 /// A binary search routine, based on Rust's `std::slice::binary_search_by`.

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,7 +18,6 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
-typedef struct TSLanguageMetadata TSLanguageMetadata;
 typedef struct TSLanguageMetadata {
   uint8_t major_version;
   uint8_t minor_version;

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,6 +18,7 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata TSLanguageMetadata;
 typedef struct TSLanguageMetadata {
   uint8_t major_version;
   uint8_t minor_version;

--- a/test/corpus/components.txt
+++ b/test/corpus/components.txt
@@ -219,4 +219,56 @@ PHP syntax inside attribute values
           (attribute_value))))
     (text)
     (end_tag
+     (tag_name))))
+
+================================================================================
+Scoped Slots
+================================================================================
+
+<x-alert>
+    <x-slot>
+        ...
+    </x-slot>
+    <x-slot:title>
+        ...
+    </x-slot>
+    <x-slot:contents>
+        ...
+    </x-slot:contents>
+    <x-slot:title>
+        ...
+    </x-slot:other>
+</x-alert>
+
+--------------------------------------------------------------------------------
+
+(document
+  (element
+    (start_tag
+      (tag_name))
+    (element
+      (start_tag
+        (tag_name))
+      (text)
+      (end_tag
+        (tag_name)))
+    (element
+      (start_tag
+        (tag_name))
+      (text)
+      (end_tag
+        (tag_name)))
+    (element
+      (start_tag
+        (tag_name))
+      (text)
+      (end_tag
+        (tag_name)))
+    (element
+      (start_tag
+        (tag_name))
+      (text))
+    (erroneous_end_tag
+      (erroneous_end_tag_name))
+    (end_tag
       (tag_name))))


### PR DESCRIPTION
Fixes #107.

Looks like it was never really properly fixed.

Supports both variants:
```html
<x-slot:name>
...
</x-slot>

<x-slot:name>
...
</x-slot:name>
```

# Checklist

- [x] `deno check main/` to make sure the source code is fine
- [x] `deno lint main/` to utilise the linter. You could also do
      `deno lint --fix main/` to automatically fix
- [x] `deno run generate` ensure you include everything in the `src/*` - [ ] All
      tests pass in CI
- [x] There are enough tests for the new fix/feature
- [x] Grammar rules have not been renamed unless absolutely necessary (x rules
      renamed)
- [x] The conflicts section hasn't grown too much (x new conflicts)
- [x] The parser size hasn't grown too much (master: STATE_COUNT, PR:
      STATE_COUNT) >Check the value of STATE_COUNT in src/parser.c it should be
      roughly ~5k
