### PR TITLE
Fix: directives in tags, dynamic tags, void elements, nested parents, email handling

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1090,12 +1090,12 @@ var grammar_default = grammar(import_grammar.default, {
     // !directive parameter
     _directive_parameter: ($) => seq(
       "(",
-      optional(repeat($.parameter)),
+      optional(repeat(choice($.parameter, ","))),
       ")"
     ),
     // !parenthesis balancing - for functions/casts
-    parameter: ($) => choice(/[^()]+/, $._nested_parenthases),
-    _nested_parenthases: ($) => seq("(", repeat($.parameter), ")"),
+    parameter: ($) => choice(/[^,()]+/, $._nested_parenthases),
+    _nested_parenthases: ($) => seq("(", repeat(choice($.parameter, ",")), ")"),
     text: ($) => prec.right(repeat1($._text)),
     // hidden to reduce AST noise in php_only #39
     // It is selectively unhidden for other areas

--- a/grammar.js
+++ b/grammar.js
@@ -278,6 +278,82 @@ var grammar_default = grammar(import_grammar.default, {
     ),
     // ! PHP Statements
     php_statement: ($) => choice($._escaped, $._unescaped, $._setup, $._raw, $._php),
+    // Override element to support dynamic Blade tags: <{{ $tag }}>...</{{ $tag }}>
+    element: ($) => choice(
+      seq(
+        $.start_tag,
+        repeat($._node),
+        choice($.end_tag, $._implicit_end_tag)
+      ),
+      $.self_closing_tag,
+      seq(
+        $.dynamic_start_tag,
+        repeat($._node),
+        $.dynamic_end_tag
+      )
+    ),
+    dynamic_start_tag: ($) => seq(
+      "<",
+      $.php_statement,
+      repeat($.attribute),
+      ">"
+    ),
+    dynamic_end_tag: ($) => seq(
+      "</",
+      $.php_statement,
+      ">"
+    ),
+    // Override start_tag to allow Blade directive fragments inside tags:
+    // <li @if($x) class="active" @endif>
+    start_tag: ($) => seq(
+      "<",
+      alias($._start_tag_name, $.tag_name),
+      repeat(choice(
+        $.attribute,
+        $.comment,
+        $._tag_directive
+      )),
+      ">"
+    ),
+    self_closing_tag: ($) => seq(
+      "<",
+      alias($._start_tag_name, $.tag_name),
+      repeat(choice(
+        $.attribute,
+        $.comment,
+        $._tag_directive
+      )),
+      "/>"
+    ),
+    _tag_directive: ($) => choice(
+      alias(token(prec(1, /@end[a-zA-Z]+/)), $.directive_end),
+      seq(alias("@if", $.directive_start), $._directive_parameter),
+      seq(alias("@unless", $.directive_start), $._directive_parameter),
+      seq(alias("@isset", $.directive_start), $._directive_parameter),
+      seq(alias("@empty", $.directive_start), $._directive_parameter),
+      seq(alias("@foreach", $.directive_start), $._directive_parameter),
+      seq(alias("@forelse", $.directive_start), $._directive_parameter),
+      seq(alias("@for", $.directive_start), $._directive_parameter),
+      seq(alias("@while", $.directive_start), $._directive_parameter),
+      seq(alias("@switch", $.directive_start), $._directive_parameter),
+      seq(alias("@case", $.directive), $._directive_parameter),
+      seq(alias("@push", $.directive_start), $._directive_parameter),
+      seq(alias("@section", $.directive_start), $._directive_parameter),
+      seq(alias("@auth", $.directive_start), optional($._directive_parameter)),
+      seq(alias("@guest", $.directive_start), optional($._directive_parameter)),
+      seq(alias("@can", $.directive_start), $._directive_parameter),
+      seq(alias("@cannot", $.directive_start), $._directive_parameter),
+      seq(alias("@error", $.directive_start), optional($._directive_parameter)),
+      seq(alias("@env", $.directive_start), $._directive_parameter),
+      seq(alias("@hasSection", $.directive_start), $._directive_parameter),
+      seq(alias("@sectionMissing", $.directive_start), $._directive_parameter),
+      seq(alias("@elseif", $.directive), $._directive_parameter),
+      alias("@else", $.directive),
+      alias("@default", $.directive),
+      alias("@break", $.directive),
+      alias("@continue", $.directive),
+      $.keyword
+    ),
     // From tree-sitter-php
     _php: ($) => seq(
       $.php_tag,
@@ -372,7 +448,11 @@ var grammar_default = grammar(import_grammar.default, {
       $._directive_parameter
     ),
     // !inline directives
-    _inline_directive: ($) => seq(
+    // Known directives get explicit `directive` node type. The catch-all regex
+    // (same token prec as _custom) ensures GLR explores BOTH paths for unknown
+    // @word(...). prec.dynamic(-1) on the whole rule means _custom (dynamic 1)
+    // wins when @endword exists; inline wins when it doesn't.
+    _inline_directive: ($) => prec.dynamic(-1, seq(
       alias(
         choice(
           "@include",
@@ -406,12 +486,28 @@ var grammar_default = grammar(import_grammar.default, {
           "@field",
           "@options",
           // WireUI
-          "@wireUiScripts"
+          "@wireUiScripts",
+          // Laravel core — localization
+          "@lang",
+          "@trans",
+          "@choice",
+          // Laravel core — debugging
+          "@dd",
+          "@dump",
+          // Laravel core — forms/session
+          "@old",
+          // Common packages
+          "@route",
+          "@cache",
+          "@entangle",
+          // Catch-all: any @word not explicitly listed.
+          // Same token prec as _custom so GLR explores both paths.
+          token(prec(-1, /@[a-zA-Z_][a-zA-Z\d_]*/))
         ),
         $.directive
       ),
       $._directive_parameter
-    ),
+    )),
     // !nested directives
     fragment: ($) => seq(
       alias("@fragment", $.directive_start),
@@ -713,14 +809,17 @@ var grammar_default = grammar(import_grammar.default, {
       alias("@endfeature", $.directive_end)
     ),
     // !Custom if Statements
-    _custom: ($) => seq(
+    // prec.dynamic(1) ensures this wins over the _inline_directive catch-all
+    // when BOTH paths complete (i.e. @endword exists). When no @endword follows,
+    // only the inline path completes, so inline wins by default.
+    _custom: ($) => prec.dynamic(1, seq(
       choice(
         alias(/@unless[a-zA-Z\d]+/, $.directive_start),
         alias(token(prec(-1, /@[a-zA-Z\d]+/)), $.directive_start)
       ),
       $._conditional_directive_body,
       alias(token(prec(1, /@end[a-zA-Z\d]+/)), $.directive_end)
-    ),
+    )),
     // !switch
     switch: ($) => seq(
       alias("@switch", $.directive_start),
@@ -890,7 +989,7 @@ var grammar_default = grammar(import_grammar.default, {
     ),
     _volt: ($) => seq(
       alias("@volt", $.directive_start),
-      $._directive_parameter,
+      optional($._directive_parameter),
       repeat1(
         choice(
           ...nodes.without(
@@ -1010,6 +1109,9 @@ var grammar_default = grammar(import_grammar.default, {
         choice(
           $._escaped_directive,
           token(prec(-2, /[{}]/)),
+          // Match @-words (emails like user@gmail.com) as literal text
+          // BEFORE the _inline_directive catch-all (prec -1) can grab them
+          token(prec(0, /@[a-zA-Z_][a-zA-Z\d_]*/)),
           token(prec(-1, /[^'{}]/))
         )
       )
@@ -1019,6 +1121,9 @@ var grammar_default = grammar(import_grammar.default, {
         choice(
           $._escaped_directive,
           token(prec(-2, /[{}]/)),
+          // Match @-words (emails like user@gmail.com) as literal text
+          // BEFORE the _inline_directive catch-all (prec -1) can grab them
+          token(prec(0, /@[a-zA-Z_][a-zA-Z\d_]*/)),
           token(prec(-1, /[^"{}]/))
         )
       )

--- a/grammar.js
+++ b/grammar.js
@@ -325,6 +325,20 @@ var grammar_default = grammar(import_grammar.default, {
       )),
       "/>"
     ),
+    // Override end_tag to support mixed literal+dynamic tags: </h{{ $h }}>
+    end_tag: ($) => choice(
+      seq(
+        "</",
+        alias($._end_tag_name, $.tag_name),
+        ">"
+      ),
+      seq(
+        "</",
+        alias($._end_tag_name, $.tag_name),
+        $.php_statement,
+        ">"
+      )
+    ),
     _tag_directive: ($) => choice(
       alias(token(prec(1, /@end[a-zA-Z]+/)), $.directive_end),
       seq(alias("@if", $.directive_start), $._directive_parameter),
@@ -536,7 +550,7 @@ var grammar_default = grammar(import_grammar.default, {
         "(",
         alias(/[^,()]+/, $.parameter),
         ",",
-        alias(/[^,()]+/, $.parameter),
+        alias(/[^,()]+(\([^()]*\)[^,()]*)*/, $.parameter),
         ")"
       ),
       seq(
@@ -1109,9 +1123,9 @@ var grammar_default = grammar(import_grammar.default, {
         choice(
           $._escaped_directive,
           token(prec(-2, /[{}]/)),
-          // Match @-words (emails like user@gmail.com) as literal text
+          // Match @-words (emails like user@gmail.com, npm @scope/pkg) as literal text
           // BEFORE the _inline_directive catch-all (prec -1) can grab them
-          token(prec(0, /@[a-zA-Z_][a-zA-Z\d_]*/)),
+          token(prec(0, /@[a-zA-Z\d_]+/)),
           token(prec(-1, /[^'{}]/))
         )
       )
@@ -1121,9 +1135,9 @@ var grammar_default = grammar(import_grammar.default, {
         choice(
           $._escaped_directive,
           token(prec(-2, /[{}]/)),
-          // Match @-words (emails like user@gmail.com) as literal text
+          // Match @-words (emails like user@gmail.com, npm @scope/pkg) as literal text
           // BEFORE the _inline_directive catch-all (prec -1) can grab them
-          token(prec(0, /@[a-zA-Z_][a-zA-Z\d_]*/)),
+          token(prec(0, /@[a-zA-Z\d_]+/)),
           token(prec(-1, /[^"{}]/))
         )
       )

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -300,6 +300,17 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
         skip(lexer);
     }
 
+    // Void elements (input, br, img, etc.) must always be implicitly closed,
+    // even when followed by Blade directives like @endif, @endforeach
+    if (valid_symbols[IMPLICIT_END_TAG] && scanner->tags.size > 0) {
+        Tag *parent = array_back(&scanner->tags);
+        if (tag_is_void(parent)) {
+            pop_tag(scanner);
+            lexer->result_symbol = IMPLICIT_END_TAG;
+            return true;
+        }
+    }
+
     switch (lexer->lookahead) {
         case '<':
             lexer->mark_end(lexer);


### PR DESCRIPTION
## Grammar Fixes

### Catch-all for unknown inline directives
Many packages register custom directives (`@flash`, `@form`, `@wireUiScripts`) 
not in the grammar. Added `prec(-1)` catch-all regex so unknown `@word(...)` 
parses instead of breaking the tree.

### Custom if-statements (`@unlessany`, `@endunlessany`, etc.)
Wrapped `_custom` in `prec.dynamic(1)` and `_inline_directive` in 
`prec.dynamic(-1)`. GLR explores both paths; `_custom` wins when `@endword` 
exists, inline wins otherwise.

### `@volt` without parameters
`@volt` can be used bare (`@volt ... @endvolt`). Changed required parameter 
to `optional()`.

### Explicit inline directives
Added `@lang`, `@trans`, `@choice`, `@dd`, `@dump`, `@old`, `@route`, 
`@cache`, `@entangle`.

### `@` in email addresses inside HTML attributes
`href="mailto:user@gmail.com"` — `@gmail` was parsed as a directive. Added 
`prec(0)` rule for `@`-words inside `_singly/_doubly_quoted_attribute_text`, 
beating the catch-all at `prec(-1)`.

### Dynamic Blade tags `<{{ $tag }}>`
Dynamic tag names broke the parser. Added `dynamic_start_tag` / 
`dynamic_end_tag` rules using `$.php_statement`.

### Void elements inside conditionals
`<ul>@if($x)<input>@endif</ul>` — scanner didn't emit `IMPLICIT_END_TAG` for 
void elements followed by Blade directives. Added void parent check in 
`scan()` before the switch statement.

### Blade directives inside HTML tags
`<li @if($active) class="active" @endif>` — directives inside tags conflicted 
with `attribute_name`. Overrode `start_tag` / `self_closing_tag` with 
`_tag_directive` using literal strings (high precedence) for known directives.

### `@section` with nested function calls
`@section('title', __('Not Found'))` — second parameter regex `[^,()]+` 
couldn't handle nested parens. Changed to `/[^,()]+(\([^()]*\)[^,()]*)*/` 
to support one level of nesting.

### Mixed literal+dynamic tags `<h{{ $h }}>`
`<h{{ $h }}></h{{ $h }}>` — start tag parsed fine but end tag failed. 
Overrode `end_tag` to optionally include a trailing `$.php_statement`.

### `@` + digit in attribute values
`src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"` — `@4` not 
matched by `@[a-zA-Z_]` regex. Changed to `/@[a-zA-Z\d_]+/`.